### PR TITLE
Update proxy.go

### DIFF
--- a/Chapter04/proxy/proxy.go
+++ b/Chapter04/proxy/proxy.go
@@ -23,7 +23,7 @@ func (t *UserList) FindUser(id int32) (User, error) {
 		}
 	}
 
-	return User{}, fmt.Errorf("User %s could not be found\n", id)
+	return User{}, fmt.Errorf("User %d could not be found\n", id)
 }
 
 //AddUser adds a new user to the end of the Users slice


### PR DESCRIPTION
Fix: `./proxy.go:26:17: Errorf format %s has arg id of wrong type int32`

@packtpavanr