### PR TITLE
Add Chapter 10 pubsub example

### DIFF
--- a/Chapter10/pubsub/publisher.go
+++ b/Chapter10/pubsub/publisher.go
@@ -1,0 +1,67 @@
+package pubsub
+
+type publisher struct {
+	subscribers []Subscriber
+	addSubCh    chan Subscriber
+	removeSubCh chan Subscriber
+	in          chan interface{}
+	stop        chan struct{}
+}
+
+func NewPublisher() Publisher {
+	p := &publisher{
+		subscribers: make([]Subscriber, 0),
+		addSubCh:    make(chan Subscriber),
+		removeSubCh: make(chan Subscriber),
+		in:          make(chan interface{}),
+		stop:        make(chan struct{}),
+	}
+	go p.start()
+	return p
+}
+
+func (p *publisher) start() {
+	for {
+		select {
+		case msg := <-p.in:
+			for _, sub := range p.subscribers {
+				sub.Notify(msg)
+			}
+		case sub := <-p.addSubCh:
+			p.subscribers = append(p.subscribers, sub)
+		case sub := <-p.removeSubCh:
+			for i, candidate := range p.subscribers {
+				if candidate == sub {
+					p.subscribers = append(p.subscribers[:i],
+						p.subscribers[i+1:]...)
+					candidate.Close()
+					break
+				}
+			}
+		case <-p.stop:
+			for _, sub := range p.subscribers {
+				sub.Close()
+			}
+			close(p.addSubCh)
+			close(p.in)
+			close(p.removeSubCh)
+			return
+		}
+	}
+}
+
+func (p *publisher) AddSubscriberCh() chan<- Subscriber {
+	return p.addSubCh
+}
+
+func (p *publisher) RemoveSubscriberCh() chan<- Subscriber {
+	return p.removeSubCh
+}
+
+func (p *publisher) PublishingCh() chan<- interface{} {
+	return p.in
+}
+
+func (p *publisher) Stop() {
+	close(p.stop)
+}

--- a/Chapter10/pubsub/publisher_test.go
+++ b/Chapter10/pubsub/publisher_test.go
@@ -1,0 +1,63 @@
+package pubsub
+
+import (
+	"errors"
+	"sync"
+	"testing"
+)
+
+type mockSubscriber struct {
+	notifyTestingFunc func(msg interface{})
+	closeTestingFunc  func()
+}
+
+func (m *mockSubscriber) Close() {
+	m.closeTestingFunc()
+}
+
+func (m *mockSubscriber) Notify(msg interface{}) error {
+	m.notifyTestingFunc(msg)
+	return nil
+}
+
+func TestPublisher(t *testing.T) {
+	msg := "Hello"
+	p := NewPublisher()
+
+	var wg sync.WaitGroup
+	sub := &mockSubscriber{
+		notifyTestingFunc: func(msg interface{}) {
+			defer wg.Done()
+			s, ok := msg.(string)
+			if !ok {
+				t.Fatal(errors.New("Could not assert result"))
+			}
+			if s != msg {
+				t.Fail()
+			}
+		},
+		closeTestingFunc: func() {
+			wg.Done()
+		},
+	}
+	p.AddSubscriberCh() <- sub
+
+	wg.Add(1)
+	p.PublishingCh() <- msg
+	wg.Wait()
+
+	pubCon := p.(*publisher)
+	if len(pubCon.subscribers) != 1 {
+		t.Error("Unexpected number of subscribers")
+	}
+
+	wg.Add(1)
+	p.RemoveSubscriberCh() <- sub
+	wg.Wait()
+
+	//Number of subscribers is restored to zero
+	if len(pubCon.subscribers) != 0 {
+		t.Error("Expected no subscribers")
+	}
+	p.Stop()
+}

--- a/Chapter10/pubsub/pubsub.go
+++ b/Chapter10/pubsub/pubsub.go
@@ -1,0 +1,14 @@
+package pubsub
+
+type Subscriber interface {
+	Notify(interface{}) error
+	Close()
+}
+
+type Publisher interface {
+	start()
+	AddSubscriberCh() chan<- Subscriber
+	RemoveSubscriberCh() chan<- Subscriber
+	PublishingCh() chan<- interface{}
+	Stop()
+}

--- a/Chapter10/pubsub/writer_sub.go
+++ b/Chapter10/pubsub/writer_sub.go
@@ -1,0 +1,49 @@
+package pubsub
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"time"
+)
+
+type writerSubscriber struct {
+	in     chan interface{}
+	id     int
+	Writer io.Writer
+}
+
+func NewWriterSubscriber(id int, out io.Writer) Subscriber {
+	if out == nil {
+		out = os.Stdout
+	}
+	s := &writerSubscriber{
+		id:     id,
+		in:     make(chan interface{}),
+		Writer: out,
+	}
+	go func() {
+		for msg := range s.in {
+			fmt.Fprintf(s.Writer, "(W%d): %v\n", s.id, msg)
+		}
+	}()
+	return s
+}
+
+func (s *writerSubscriber) Notify(msg interface{}) (err error) {
+	defer func() {
+		if rec := recover(); rec != nil {
+			err = fmt.Errorf("%#v", rec)
+		}
+	}()
+	select {
+	case s.in <- msg:
+	case <-time.After(time.Second):
+		err = fmt.Errorf("Timeout\n")
+	}
+	return
+}
+
+func (s *writerSubscriber) Close() {
+	close(s.in)
+}

--- a/Chapter10/pubsub/writer_sub_test.go
+++ b/Chapter10/pubsub/writer_sub_test.go
@@ -1,0 +1,40 @@
+package pubsub
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+)
+
+type mockWriter struct {
+	testingFunc func(string)
+}
+
+func (m *mockWriter) Write(p []byte) (n int, err error) {
+	m.testingFunc(string(p))
+	return len(p), nil
+}
+
+func TestWriter(t *testing.T) {
+	sub := NewWriterSubscriber(0, nil)
+	msg := "Hello"
+	var wg sync.WaitGroup
+	wg.Add(1)
+	stdoutPrinter := sub.(*writerSubscriber)
+	stdoutPrinter.Writer = &mockWriter{
+		testingFunc: func(res string) {
+			if !strings.Contains(res, msg) {
+				t.Fatal(fmt.Errorf("Incorrect string: %s", res))
+			}
+			wg.Done()
+		},
+	}
+	err := sub.Notify(msg)
+	if err != nil {
+		wg.Done()
+		t.Error(err)
+	}
+	wg.Wait()
+	sub.Close()
+}


### PR DESCRIPTION
Not sure why, but the Chapter 10 Pub/Sub example is entirely missing from the code.
I copied it as-written in the book, fixing a few typos along the way. It compiles and the tests pass.